### PR TITLE
Implement BigTIFF Necessity Check

### DIFF
--- a/jnormcorre/motion_correction.py
+++ b/jnormcorre/motion_correction.py
@@ -2634,7 +2634,17 @@ def tile_and_correct_dataloader(param_list, split_constant=200):
 
                 
         if out_fname is not None:
-             tifffile.imwrite(out_fname, mc, append=True, metadata=None)
+
+            element_size_in_bytes = mc.dtype.itemsize
+            total_size_in_bytes = mc.size * element_size_in_bytes
+
+            # Check if total size is close to or exceeds 4 GB
+            if total_size_in_bytes >= (4 * 1024 * 1024 * 1024):
+                big_tiff=True
+            else:
+                big_tiff=False
+
+            tifffile.imwrite(out_fname, mc, append=True, metadata=None, bigtiff=big_tiff)
 
         new_temp = generate_template_chunk(mc)
         


### PR DESCRIPTION
Description:
This commit introduces a check to determine whether the `bigtiff=True` parameter should be used when exporting TIFF files (save_movie=True). The necessity of using BigTIFF is assessed based on the size of the data array to be written. If the total size of the array is close to or exceeds 4 GB, `bigtiff=True` is used to prevent errors related to file size limitations in the standard TIFF format. This enhancement aims to avoid the "data too large for non-BigTIFF file" error that occurs when attempting to write large files in the standard TIFF format.